### PR TITLE
chore: Update GitHub Actions workflow to deploy to gh-pages-pdoc branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: gh-docs/
-          branch: gh-pages
+          branch: gh-pages-pdoc
   packages:
     permissions:
       # If you do not supply the action with an access token or an SSH key, you must access your repositories settings and provide Read and Write Permissions to the provided GITHUB_TOKEN, otherwise you'll potentially run into permission issues. Alternatively you can set the following in your workflow file to grant the action the permissions it needs.


### PR DESCRIPTION
Let me analyze the diff and write out the changes in markdown format.

# Pull Request Changes 📝

## GitHub Actions Workflow Modification

### File: `.github/workflows/publish.yml`

**Branch Target Change:**
- Changed the deployment target branch from `gh-pages` to `gh-pages-pdoc` in the GitHub Pages deploy action configuration

```diff
- branch: gh-pages
+ branch: gh-pages-pdoc
```

This change modifies where the documentation is deployed, switching from the standard GitHub Pages branch to a custom branch named `gh-pages-pdoc` 📚

The modification appears to be part of the GitHub Pages deployment workflow, specifically in the JamesIves/github-pages-deploy-action@v4 action configuration. This could indicate a change in documentation hosting strategy or separation of documentation deployments 🔄
