### PR TITLE
chore: Enhance Justfile with release management tasks

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,18 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of strings.
+  labels: []
+# Configuration variables in array of strings defined in your repository or
+# organization. `null` means disabling configuration variables check.
+# Empty array means no configuration variable is allowed.
+config-variables: null
+
+# Path-specific configurations.
+paths:
+  # Glob pattern relative to the repository root for matching files. The path separator is always '/'.
+  # This example configures any YAML file under the '.github/workflows/' directory.
+  .github/workflows/**/*.{yml,yaml}:
+    # List of regular expressions to filter errors by the error messages.
+    ignore:
+      # Ignore the specific error from shellcheck
+      - "shellcheck reported issue in this script: SC2086:.+"
+      - "shellcheck reported issue in this script: SC2129:.+"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,11 +7,6 @@ runs:
       uses: astral-sh/setup-uv@v5
       with:
         enable-cache: true
-        persist-credentials: false
-        cache-dependency-glob: |
-          **/requirements*.txt
-          **/pyproject.toml
-          **/uv.lock
     - name: Setup Python
       uses: actions/setup-python@v5
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -173,6 +173,11 @@ repos:
       - id: commitizen-branch
         stages: [pre-push]
 
+  # - repo: https://github.com/rhysd/actionlint
+  #   rev: v1.7.7
+  #   hooks:
+  #     - id: actionlint
+
   # - repo: local
   #   hooks:
   #       - id: uv-lock-check

--- a/Justfile
+++ b/Justfile
@@ -228,3 +228,19 @@ doc-build format="google" output="gh-docs": clean-docs
 [group('doc')]
 doc-serve format="google" port="8088":
     uv run pdoc --docformat={{format}} --port={{port}} {{SOURCES}}/{{PACKAGE}}
+
+# run release tasks
+[group('release')]
+release: release-create
+
+# create a GitHub release with version from pyproject.toml
+[group('release')]
+release-create:
+    #!/usr/bin/env zsh
+    VERSION=$({{GREP_CMD}} -h '^version = ".*"' pyproject.toml | {{SED_CMD}} 's/^version = "\(.*\)"/\1/')
+    uv run gh release create "v$VERSION" --generate-notes
+
+# list all GitHub releases
+[group('release')]
+release-list:
+    uv run gh release list

--- a/Justfile
+++ b/Justfile
@@ -238,7 +238,22 @@ release: release-create
 release-create:
     #!/usr/bin/env zsh
     VERSION=$({{GREP_CMD}} -h '^version = ".*"' pyproject.toml | {{SED_CMD}} 's/^version = "\(.*\)"/\1/')
+    if [ -z "$VERSION" ]; then
+        echo "Error: Could not extract version from pyproject.toml"
+        exit 1
+    fi
     uv run gh release create "v$VERSION" --generate-notes
+
+# dry run of creating a GitHub release (echoes the command instead of executing it)
+[group('release')]
+release-create-dry-run:
+    #!/usr/bin/env zsh
+    VERSION=$({{GREP_CMD}} -h '^version = ".*"' pyproject.toml | {{SED_CMD}} 's/^version = "\(.*\)"/\1/')
+    if [ -z "$VERSION" ]; then
+        echo "Error: Could not extract version from pyproject.toml"
+        exit 1
+    fi
+    echo "Would run: gh release create \"v$VERSION\" --generate-notes"
 
 # list all GitHub releases
 [group('release')]


### PR DESCRIPTION
# PR Changes Summary

## GitHub Actions Configuration Update
**File: `.github/actions/setup/action.yml`**

### Removed Configuration
The following cache-related configurations were removed from the UV setup action:
- Removed `persist-credentials: false`
- Removed cache dependency glob patterns that were targeting:
  - `requirements*.txt`
  - `pyproject.toml`
  - `uv.lock`

This simplification maintains the core UV setup with cache enabled but removes specific caching patterns 🔧

## Justfile Enhancements
**File: `Justfile`**

### Added New Release Management Commands
Several new release-related commands were added to streamline the release process:

1. `release` - Top-level command that triggers release creation
2. `release-create` - Creates a GitHub release using the version from `pyproject.toml`
   - Automatically extracts version number from pyproject.toml
   - Creates a GitHub release with the format `v{VERSION}`
   - Generates release notes automatically
3. `release-list` - Lists all GitHub releases for the repository

All these commands are grouped under the `release` group for better organization 📦

### Technical Details
- The release commands utilize `uv run` for executing GitHub CLI commands
- Version extraction is handled through shell commands using grep and sed
- Release notes are auto-generated using GitHub's built-in functionality

These changes enhance the project's release management capabilities while simplifying the GitHub Actions setup ✨
