### PR TITLE
chore: Update CI and publish workflows with additional steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,11 @@ jobs:
         with:
           limit-access-to-actor: true
 
+      - name: Install additional ubuntu dependencies zsh etc
+        run: |
+          apt-get update
+          apt-get install zsh -y
+
       - name: Sync dependencies with UV
         run: uv sync --all-groups
 


### PR DESCRIPTION
# Add zsh Installation to GitHub Actions Workflow

## Changes
- Added a new step in the publish workflow to install `zsh` and update package lists
- This ensures the workflow environment has the required shell dependencies

## Technical Details
- Uses `apt-get` to update package lists and install `zsh`
- Added between the access limit check and UV dependency sync steps
- Installation is performed using the `-y` flag to automatically accept prompts

## Impact
This change ensures that the GitHub Actions environment has `zsh` available, which may be required for certain shell operations or scripts in the workflow 🛠️

