### PR TITLE
chore: Enhance Justfile with GitHub release deletion tasks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,8 +54,8 @@ jobs:
 
       - name: Install additional ubuntu dependencies zsh etc
         run: |
-          apt-get update
-          apt-get install zsh -y
+          sudo apt-get update
+          sudo apt-get install zsh -y
 
       - name: Sync dependencies with UV
         run: uv sync --all-groups

--- a/Justfile
+++ b/Justfile
@@ -259,3 +259,25 @@ release-create-dry-run:
 [group('release')]
 release-list:
     uv run gh release list
+
+# delete a GitHub release with version from pyproject.toml
+[group('release')]
+release-delete:
+    #!/usr/bin/env zsh
+    VERSION=$({{GREP_CMD}} -h '^version = ".*"' pyproject.toml | {{SED_CMD}} 's/^version = "\(.*\)"/\1/')
+    if [ -z "$VERSION" ]; then
+        echo "Error: Could not extract version from pyproject.toml"
+        exit 1
+    fi
+    uv run gh release delete "v$VERSION" --cleanup-tag
+
+# dry run of deleting a GitHub release (echoes the command instead of executing it)
+[group('release')]
+release-delete-dry-run:
+    #!/usr/bin/env zsh
+    VERSION=$({{GREP_CMD}} -h '^version = ".*"' pyproject.toml | {{SED_CMD}} 's/^version = "\(.*\)"/\1/')
+    if [ -z "$VERSION" ]; then
+        echo "Error: Could not extract version from pyproject.toml"
+        exit 1
+    fi
+    echo "Would run: gh release delete \"v$VERSION\" --cleanup-tag"


### PR DESCRIPTION
- Added tasks to delete a GitHub release based on the version specified in pyproject.toml, including error handling for version extraction.
- Introduced a dry run option for the delete task to preview the command without executing it.
- Updated publish workflow to use sudo for installing additional dependencies, ensuring proper permissions.

