### PR TITLE
chore: Update publish workflow and type annotations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
           brew install zsh || true
 
       - name: Sync dependencies with UV
-        run: uv sync --all-groups
+        run: uv sync --dev
 
       - name: Build documentation
         run: uv run just doc

--- a/src/codegen_lab/cli.py
+++ b/src/codegen_lab/cli.py
@@ -42,7 +42,7 @@ import os
 import sys
 import traceback
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
 import typer
 from mcp import ClientSession, StdioServerParameters
@@ -120,7 +120,7 @@ class InputValidationError(MCPClientError):
 class StdioServerConfig(BaseModel):
     """Configuration for a stdio server."""
 
-    type: str = Field("stdio", const=True)
+    type: Literal["stdio"] = "stdio"
     command: str
     args: list[str] = Field(default_factory=list)
     env: dict[str, str] = Field(default_factory=dict)
@@ -129,7 +129,7 @@ class StdioServerConfig(BaseModel):
 class SSEServerConfig(BaseModel):
     """Configuration for an SSE server."""
 
-    type: str = Field("sse", const=True)
+    type: Literal["sse"] = "sse"
     url: str
     headers: dict[str, str] = Field(default_factory=dict)
 


### PR DESCRIPTION
- Changed the dependency sync command in the publish workflow from `uv sync --all-groups` to `uv sync --dev`.
- Updated type annotations in `cli.py` to use `Literal` for specific string values in `StdioServerConfig` and `SSEServerConfig` classes.
