### PR TITLE
chore: add Codecov configuration and enhance Justfiles for formatting…

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,15 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: "30...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto
+    patch: off

--- a/justfiles/format.just
+++ b/justfiles/format.just
@@ -11,3 +11,10 @@ format-import:
 [group('format')]
 format-source:
 	uv run ruff format {{SOURCES}} {{TESTS}}
+
+# format markdown
+[group('format')]
+format_markdown:
+    @echo "Formatting markdown files..."
+    @echo "SOURCE: https://github.com/tmux-python/tmuxp/blob/master/Makefile"
+	npx prettier --parser=markdown -w *.md docs/*.md docs/**/*.md CHANGES

--- a/justfiles/monkeytype.just
+++ b/justfiles/monkeytype.just
@@ -1,0 +1,9 @@
+# Run monkeytype to collect type information during test execution
+[group('monkeytype')]
+monkeytype_create:
+    uv run monkeytype run `uv run which py.test`
+
+# Apply collected type information to all modules
+[group('monkeytype')]
+monkeytype_apply:
+    uv run monkeytype list-modules | xargs -n1 -I{} sh -c 'uv run monkeytype apply {}'


### PR DESCRIPTION
# 🛠️ Development Infrastructure Enhancements

## Overview
This PR introduces several key infrastructure improvements to enhance code quality, testing, and documentation workflows.

## 🔍 Changes

### 1. Code Coverage Configuration
- Added `.codecov.yml` for precise coverage reporting
- Configured coverage precision to 2 decimal points
- Set coverage range from 30% to 100%
- Disabled patch checks
- Configured project status checks with 1% threshold

### 2. Formatting Improvements
- Enhanced `justfiles/format.just` with markdown formatting capabilities
- Added new markdown formatting task using Prettier
- Supports formatting for:
  - Root markdown files
  - Documentation files in `docs/`
  - Nested documentation in `docs/**/`
  - CHANGES file

### 3. Type Information Management
- Added new `justfiles/monkeytype.just` for runtime type information collection
- Introduced two new commands:
  - `monkeytype_create`: Collects type information during test execution
  - `monkeytype_apply`: Applies collected type information to all modules

## 🔧 Technical Details

### Code Coverage Configuration
```yaml
coverage:
  precision: 2
  round: down
  range: "30...100"
```

### Formatting Command
```just
format_markdown:
    @echo "Formatting markdown files..."
    npx prettier --parser=markdown -w *.md docs/*.md docs/**/*.md CHANGES
```

### MonkeyType Integration
```just
monkeytype_create:
    uv run monkeytype run `uv run which py.test`
monkeytype_apply:
    uv run monkeytype list-modules | xargs -n1 -I{} sh -c 'uv run monkeytype apply {}'
```

## 📋 Testing Instructions
1. Run code coverage checks to verify configuration
2. Test markdown formatting with `just format_markdown`
3. Verify MonkeyType type collection and application

## 🎯 Impact
- Improved code quality monitoring through precise coverage metrics
- Consistent documentation formatting across the project
- Enhanced type safety through runtime type information collection

## 📝 Notes
- Coverage configuration is set to not require CI pass for notifications
- Markdown formatting follows the tmuxp project's approach
- MonkeyType integration requires pytest to be installed ✨
