### PR TITLE
refactor: replace grep -P with cross-platform sed command

### DIFF
--- a/scripts/ci/cz-prepare-release.sh
+++ b/scripts/ci/cz-prepare-release.sh
@@ -54,7 +54,7 @@ echo "✅ Current version: ${CURRENT_VERSION}"
 
 echo "===== VERSION DETERMINATION ====="
 echo "-- Running Commitizen dry-run --"
-VERSION=$(uv run cz bump --dry-run 2>&1 | grep -oP 'bump: version \S+ → \K\S+')
+VERSION=$(uv run cz bump --dry-run 2>&1 | sed -n 's/bump: version .* → \(.*\)/\1/p')
 CZ_EXIT_CODE=$?
 if [ $CZ_EXIT_CODE -ne 0 ]; then
     echo "❌ Commitizen dry-run failed with exit code $CZ_EXIT_CODE"


### PR DESCRIPTION
Modified version extraction in cz-prepare-release.sh to use sed instead of grep -P for better compatibility between macOS and Linux systems. This change ensures the script works consistently across different operating systems without requiring additional tools like ggrep on macOS.

-Agent Generated Commit Message

