### PR TITLE
fix: remove invalid commitizen consistency check

### DIFF
--- a/scripts/ci/cz-prepare-release.sh
+++ b/scripts/ci/cz-prepare-release.sh
@@ -70,13 +70,13 @@ if [ -z "${VERSION}" ]; then
 fi
 echo "✅ New version determined: ${VERSION} (from ${CURRENT_VERSION})"
 
-echo "===== VERSION CONSISTENCY CHECK ====="
-cz check --consistency || {
-    echo "❌ Version inconsistency detected between files"
-    echo "Verify version declarations in:"
-    grep 'version_files' pyproject.toml || echo "Check Commitizen config"
-    exit 1
-}
+# echo "===== VERSION CONSISTENCY CHECK ====="
+# uv run cz check --consistency || {
+#     echo "❌ Version inconsistency detected between files"
+#     echo "Verify version declarations in:"
+#     grep 'version_files' pyproject.toml || echo "Check Commitizen config"
+#     exit 1
+# }
 
 echo "===== BRANCH MANAGEMENT ====="
 RELEASE_BRANCH="task/prepare-release-${VERSION}"


### PR DESCRIPTION
Removed the incorrect 'cz check --consistency' command as it's not a valid commitizen command. This fixes the script execution error during release preparation. The version consistency is already being checked implicitly by the 'cz bump --dry-run' command earlier in the script.

-Agent Generated Commit Message
