### PR TITLE
Prepare for release of 1.0.0 to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
-## Unreleased
+## v1.1.0 (2025-04-07)
+
+### Feat
+
+- introduce git commit and push rules for consistent message formatting
+- add GitHub release automation script
+- add release preparation script with enhanced safeguards
+
+### Fix
+
+- simplify PR creation command in release preparation script
+- update GitHub CLI authentication check in release preparation script
+- remove invalid commitizen consistency check
+
+### Refactor
+
+- replace grep -P with cross-platform sed command
 
 ## v1.0.0 (2025-04-04)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@
     name = "codegen-lab"
     readme = "README.md"
     requires-python = ">=3.12"
-    version = "1.0.0"
+    version = "1.1.0"
 
     [project.scripts]
         clctl       = "codegen_lab.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -492,7 +492,7 @@ wheels = [
 
 [[package]]
 name = "codegen-lab"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "better-exceptions" },


### PR DESCRIPTION
Release preparation triggered by @Malcolm Jones.\n\nOnce merged, create a GitHub release for `1.1.0` to publish.